### PR TITLE
Update config.py

### DIFF
--- a/nonebot/adapters/satori/config.py
+++ b/nonebot/adapters/satori/config.py
@@ -20,11 +20,11 @@ class ClientInfo(BaseModel):
 
     @property
     def api_base(self):
-        return URL(f"http://{self.host}:{self.port}") / self.path / "v1"
+        return URL(f"http://{self.host}:{self.port}") / self.path.lstrip("/") / "v1"
 
     @property
     def ws_base(self):
-        return URL(f"ws://{self.host}:{self.port}") / self.path / "v1"
+        return URL(f"ws://{self.host}:{self.port}") / self.path.lstrip("/") / "v1"
 
 
 class Config(BaseModel, extra=Extra.ignore):


### PR DESCRIPTION
通常path填的是 `/path` ，但yarl.URL不允许 / 以/开头的path
加个lstrip("/")避免.....