### PR TITLE
修复 quote 里的 author 标签被忽略的问题

### DIFF
--- a/nonebot/adapters/satori/bot.py
+++ b/nonebot/adapters/satori/bot.py
@@ -54,7 +54,7 @@ async def _check_reply(bot: "Bot", event: MESSAGE_EVENTS) -> None:
     if TYPE_CHECKING:
         assert isinstance(msg_seg, RenderMessage)
     event.reply = msg_seg  # type: ignore
-    if "content" in msg_seg.data and (author_msg := msg_seg.children.get("author")):
+    if author_msg := msg_seg.children.get("author"):
         author_seg = author_msg[0]
         if TYPE_CHECKING:
             assert isinstance(author_seg, Author)


### PR DESCRIPTION
[Commit 83f41e8ee9bc56e4bf30ae57e3b8b0688f30d455](https://github.com/nonebot/adapter-satori/commit/83f41e8ee9bc56e4bf30ae57e3b8b0688f30d455#diff-339fc82101f3ec52d20bf664be77b54397ba83b7c0c4dcd905f77eea14a0b5a8L55) 中将 `msg_seg.data["content"]` 改成了 `msg_seg.children`，但前面的 `"content" in msg_seg.data` 未相应修改，导致 `<quote>` 里的 `<author>` 即使存在也会被忽略，回退到 `message_get` 的分支。